### PR TITLE
Sand 823/vpc ecs ec2

### DIFF
--- a/aws/no_vpc/director.tf
+++ b/aws/no_vpc/director.tf
@@ -59,11 +59,6 @@ resource "aws_ecs_service" "director-frontend" {
   desired_count   = 2
   launch_type     = "EC2"
 
-  network_configuration {
-    security_groups  = [aws_security_group.sandgarden_director_sg.id]
-    subnets         = data.aws_subnets.default.ids
-  }
-
   load_balancer {
     target_group_arn = aws_lb_target_group.director_nlb_tg.id
     container_name   = "sandgarden-director-ctr"

--- a/aws/no_vpc/variables.tf
+++ b/aws/no_vpc/variables.tf
@@ -50,5 +50,5 @@ variable "task_memory" {
 variable "director_version" {
   description = "Version of the Sandgarden Director image to use. If not specified, latest non-latest tag will be used."
   type        = string
-  default     = "v0.416.0"
+  default     = "v1.0.0"
 }

--- a/aws/vpc/README.md
+++ b/aws/vpc/README.md
@@ -65,7 +65,7 @@ Network Resources:
 * Security groups for NLB and ECS tasks
 
 Container Resources:
-* ECS Fargate cluster
+* ECS EC2 cluster
 * ECS task definition and service
 * ECR repository with pull-through cache
 * CloudWatch log group for container logs

--- a/aws/vpc/ec2.tf
+++ b/aws/vpc/ec2.tf
@@ -1,0 +1,46 @@
+data "aws_ssm_parameter" "ecs_node_ami" {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id"
+}
+
+resource "aws_launch_template" "director_ecs_ec2" {
+  name_prefix            = "${var.namespace}-ecs-ec2"
+  image_id               = data.aws_ssm_parameter.ecs_node_ami.value
+  instance_type          = "t2.micro"
+  vpc_security_group_ids = [aws_security_group.sandgarden_director_sg.id]
+
+  iam_instance_profile { arn = aws_iam_instance_profile.director_profile.arn }
+  monitoring { enabled = true }
+
+  user_data = base64encode(<<-EOF
+      #!/bin/bash
+      echo ECS_CLUSTER=${aws_ecs_cluster.sandgarden_director_cluster.name} >> /etc/ecs/ecs.config;
+    EOF
+  )
+}
+
+resource "aws_autoscaling_group" "director_ecs" {
+  name_prefix               = "${var.namespace}-ecs-asg"
+  vpc_zone_identifier       = [aws_subnet.private.id]
+  min_size                  = 2
+  max_size                  = 10
+  health_check_grace_period = 0
+  health_check_type         = "EC2"
+  protect_from_scale_in     = false
+
+  launch_template {
+    id      = aws_launch_template.director_ecs_ec2.id
+    version = "$Latest"
+  }
+
+  tag {
+    key                 = "Name"
+    value               = "${var.namespace}-ecs-cluster"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "AmazonECSManaged"
+    value               = ""
+    propagate_at_launch = true
+  }
+}

--- a/aws/vpc/iam.tf
+++ b/aws/vpc/iam.tf
@@ -140,6 +140,11 @@ resource "aws_iam_instance_profile" "director_profile" {
   }
 }
 
+resource "aws_iam_role_policy_attachment" "ecs_node_role_policy" {
+  role       = aws_iam_role.director_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
 resource "aws_iam_role_policy_attachment" "director_policy_attachment" {
   role       = aws_iam_role.director_role.name
   policy_arn = aws_iam_policy.director_policy.arn

--- a/aws/vpc/nlb.tf
+++ b/aws/vpc/nlb.tf
@@ -15,7 +15,7 @@ resource "aws_lb_target_group" "director_nlb_tg" {
   port        = 8987
   protocol    = "TCP"
   vpc_id      = var.vpc_id
-  target_type = "ip"
+  target_type = "instance"
 
   health_check {
     protocol            = "TCP"
@@ -58,7 +58,17 @@ resource "aws_vpc_security_group_ingress_rule" "nlb_https" {
   description       = "Allow HTTPS inbound"
 }
 
-# Allow NLB to ECS traffic
+# Allow NLB to ECS traffic (egress)
+resource "aws_vpc_security_group_egress_rule" "nlb_https" {
+  security_group_id = aws_security_group.nlb_sg.id
+  from_port         = 8987
+  to_port           = 8987
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
+  description       = "Allow director traffic outbound"
+}
+
+# Allow NLB to ECS traffic (ingress)
 resource "aws_vpc_security_group_ingress_rule" "ecs_from_nlb" {
   security_group_id = aws_security_group.sandgarden_director_sg.id
   from_port         = 8987

--- a/aws/vpc/templates/ecs/director.json.tpl
+++ b/aws/vpc/templates/ecs/director.json.tpl
@@ -3,9 +3,10 @@
     "essential": true,
     "name": "sandgarden-director-ctr",
     "image": "${sandgarden_ecr_repo_url}",
-    "cpu": ${fargate_cpu},
-    "memory": ${fargate_memory},
-    "networkMode": "awsvpc",
+    "privileged": true,
+    "cpu": ${task_cpu},
+    "memory": ${task_memory},
+    "networkMode": "host",
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {

--- a/aws/vpc/variables.tf
+++ b/aws/vpc/variables.tf
@@ -55,7 +55,7 @@ variable "fargate_memory" {
 variable "director_version" {
   description = "Version of the Sandgarden Director image to use. If not specified, latest non-latest tag will be used."
   type        = string
-  default     = "v0.400.0"
+  default     = "v1.0.0"
 }
 
 variable "public_subnet_cidr" {

--- a/aws/vpc/variables.tf
+++ b/aws/vpc/variables.tf
@@ -40,16 +40,16 @@ variable "sandgarden_ecr_repo_url" {
   default     = "public.ecr.aws"  # Changed to just the registry domain
 }
 
-variable "fargate_cpu" {
-  description = "Fargate instance CPU units (1 vCPU = 1024 CPU units)"
+variable "task_cpu" {
+  description = "ECS Task instance CPU units (1 vCPU = 1024 CPU units)"
   type        = number
   default     = 1024
 }
 
-variable "fargate_memory" {
-  description = "Fargate instance memory in MiB"
+variable "task_memory" {
+  description = "ECS Task instance memory in MiB"
   type        = number
-  default     = 2048
+  default     = 970
 }
 
 variable "director_version" {


### PR DESCRIPTION
This PR copies the ec2+ecs configuration from no_vpc to vpc. This has been tested and these containers can run docker steps without any non-terraform assets (excluding the required vpc and internet gateway for that vpc) 