### PR TITLE
SAND-882 Configure TLS termination in dev container

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -17,15 +17,10 @@ services:
       - SAND_LOG_LEVEL=debug
       - SAND_API_KEY=${SAND_API_KEY}
       - SAND_HOME=/.sandgarden
+      - SAND_TERMINATE_TLS=false
     ports:
       - "8987:8987"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ..:/workspaces/sandgarden
       - .sandgarden:/.sandgarden
-    networks:
-      - sandgarden_demo_network
-
-networks:
-  sandgarden_demo_network:
-    name: sandgarden_demo_network


### PR DESCRIPTION
- Makes the director started by the devcontainer start with TLS disabled so that users don't have to configure CAs 
- Share director port 8987 over the docker default network

Director can be accessed from the host using: `http://localhost:8987`

Director can be accessed from the devcontainer using: `http://director:8987`