### PR TITLE
aws: add s3 buckets for log outputs

### DIFF
--- a/aws/no_vpc/director.tf
+++ b/aws/no_vpc/director.tf
@@ -47,6 +47,7 @@ resource "aws_ecs_task_definition" "sandgarden_director" {
       "sand_api_key_arn"      = aws_secretsmanager_secret.director_api_key.arn
       "sandgarden_ecr_repo_url" = aws_ssm_parameter.ecr_repo_url.value
       "aws_region"            = var.aws_region
+      "s3_bucket"             = aws_s3_bucket.director_logs_bucket.bucket
     }
   )
   depends_on = [aws_cloudwatch_log_group.director]

--- a/aws/no_vpc/ec2.tf
+++ b/aws/no_vpc/ec2.tf
@@ -8,6 +8,12 @@ resource "aws_launch_template" "director_ecs_ec2" {
   instance_type          = "t2.micro"
   vpc_security_group_ids = [aws_security_group.sandgarden_director_sg.id]
 
+  metadata_options {
+    http_tokens = "required"
+    http_endpoint = "enabled"
+    instance_metadata_tags = "enabled"
+  }
+
   iam_instance_profile { arn = aws_iam_instance_profile.director_profile.arn }
   monitoring { enabled = true }
 

--- a/aws/no_vpc/iam.tf
+++ b/aws/no_vpc/iam.tf
@@ -39,6 +39,16 @@ data "aws_iam_policy_document" "director_policy" {
   statement {
     effect = "Allow"
     actions = [
+      "s3:PutObject",
+    ]
+    resources = [
+      "${aws_s3_bucket.director_logs_bucket.arn}/*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
       "ecr:*",
     ]
     resources = ["*"]
@@ -158,6 +168,11 @@ resource "aws_iam_role_policy_attachment" "execution_role_attachment" {
 resource "aws_iam_role_policy_attachment" "director_managed_core" {
   role       = aws_iam_role.director_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy" {
+  role       = aws_iam_role.director_role.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
 
 # Create separate execution role for ECS tasks

--- a/aws/no_vpc/s3.tf
+++ b/aws/no_vpc/s3.tf
@@ -1,0 +1,5 @@
+resource "aws_s3_bucket" "director_logs_bucket" {
+  bucket = "${var.namespace}-director-logs"
+
+  object_lock_enabled = true
+}

--- a/aws/no_vpc/templates/ecs/director.json.tpl
+++ b/aws/no_vpc/templates/ecs/director.json.tpl
@@ -30,6 +30,10 @@
       {
         "name": "SAND_LOG_LEVEL",
         "value": "${sand_log_level}"
+      },
+      {
+        "name": "SAND_LOG_DESTINATION",
+        "value": "s3://${s3_bucket}"
       }
     ],
     "secrets": [

--- a/aws/vpc/director.tf
+++ b/aws/vpc/director.tf
@@ -37,6 +37,7 @@ resource "aws_ecs_task_definition" "sandgarden_director" {
       "sand_api_key_arn"      = aws_secretsmanager_secret.director_api_key.arn
       "sandgarden_ecr_repo_url" = aws_ssm_parameter.ecr_repo_url.value
       "aws_region"            = var.aws_region
+      "s3_bucket"             = aws_s3_bucket.director_logs_bucket.bucket
     }
   )
   depends_on = [aws_cloudwatch_log_group.director]

--- a/aws/vpc/ec2.tf
+++ b/aws/vpc/ec2.tf
@@ -8,6 +8,12 @@ resource "aws_launch_template" "director_ecs_ec2" {
   instance_type          = "t2.micro"
   vpc_security_group_ids = [aws_security_group.sandgarden_director_sg.id]
 
+  metadata_options {
+    http_tokens = "required"
+    http_endpoint = "enabled"
+    instance_metadata_tags = "enabled"
+  }
+
   iam_instance_profile { arn = aws_iam_instance_profile.director_profile.arn }
   monitoring { enabled = true }
 

--- a/aws/vpc/iam.tf
+++ b/aws/vpc/iam.tf
@@ -39,6 +39,16 @@ data "aws_iam_policy_document" "director_policy" {
   statement {
     effect = "Allow"
     actions = [
+      "s3:PutObject",
+    ]
+    resources = [
+      "${aws_s3_bucket.director_logs_bucket.arn}/*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
       "ecr:*",
     ]
     resources = ["*"]
@@ -158,6 +168,11 @@ resource "aws_iam_role_policy_attachment" "execution_role_attachment" {
 resource "aws_iam_role_policy_attachment" "director_managed_core" {
   role       = aws_iam_role.director_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy" {
+  role       = aws_iam_role.director_role.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
 
 # Create separate execution role for ECS tasks

--- a/aws/vpc/s3.tf
+++ b/aws/vpc/s3.tf
@@ -1,0 +1,5 @@
+resource "aws_s3_bucket" "director_logs_bucket" {
+  bucket = "${var.namespace}-director-logs"
+
+  object_lock_enabled = true
+}

--- a/aws/vpc/templates/ecs/director.json.tpl
+++ b/aws/vpc/templates/ecs/director.json.tpl
@@ -30,6 +30,10 @@
       {
         "name": "SAND_LOG_LEVEL",
         "value": "${sand_log_level}"
+      },
+      {
+        "name": "SAND_LOG_DESTINATION",
+        "value": "s3://${s3_bucket}"
       }
     ],
     "secrets": [


### PR DESCRIPTION
I haven't tested the no_vpc variant, but the code changes for vpc and no_vpc are identical. 