### PR TITLE
Feature/standardize env files

### DIFF
--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -1,4 +1,0 @@
-SSH_AUTH_SOCK_PATH=/run/host-services/ssh-auth.sock
-SAND_API_KEY=YOUR_SAND_API_KEY
-GIT_USER_NAME="Your Name"
-GIT_USER_EMAIL="Your Email"

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -18,12 +18,10 @@ Dev Container provides a complete development environment for Sandgarden workflo
    cp .env .devcontainer/.env
    ```
 
-2. Edit the `.env` and replace the `YOUR_SAND_API_KEY` string with your actual Sandgarden Director API key.
-
-3. In VS Code, open the directory you cloned the `getting-started` repo to, then click the "Open a Remote Window" button in the bottom-left corner and select "Reopen in Container" from the menu.
+2. In VS Code, open the directory you cloned the `getting-started` repo to, then click the "Open a Remote Window" button in the bottom-left corner and select "Reopen in Container" from the menu.
    - This will start building the Dev Container, the first time you do it may take a few minutes to fully download build. Click “show log” in VSCode to check progress and as long as stuff is happening, it's all good.
 
-4. When the Dev Container finishes building, open another VS Code terminal and run `sand directors list` to confirm everything was successful - you should see an active Director listed. You should also see an active Director in the [Sandgarden Admin UI](https://app.sandgarden.com/infrastructure/directors).
+3. When the Dev Container finishes building, open another VS Code terminal and run `sand directors list` to confirm everything was successful - you should see an active Director listed. You should also see an active Director in the [Sandgarden Admin UI](https://app.sandgarden.com/infrastructure/directors).
    ```bash
    sand directors list
    ```

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -3,17 +3,6 @@
 Local developer mode runs a Sandgarden director in a local docker image on your development machine.
 It's a simple way to get started with Sandgarden without having to set up a cloud environment, and it lets you test your changes as you make them.
 
-## Prerequisites
-
-To get started in local developer mode, first prepare the following:
-
-1. Clone [this getting-started repo](https://github.com/sandgardenhq/getting-started.git), through either Git or VS Code.
-2. Create a Sandgarden API Key [through the Admin UI](https://app.sandgarden.com/settings/api-keys/new).
-   - Give a descriptive API Key Name (e.g. `deployment-key`).
-   - For Key Type, select "Director Key".
-   - For Expiration Date, choose a date conveniently far enough into the future (e.g. 30 days out).
-3. _(Optional)_ Create an OpenAI API Key and keep it handy, if you would like to try one of our provided example workflows after deploying a Director.
-
 ## Dev Container
 
 Dev Container provides a complete development environment for Sandgarden workflows:
@@ -24,14 +13,14 @@ Dev Container provides a complete development environment for Sandgarden workflo
 
 ### Setup
 
-1. Open the .devcontainer directory from the `getting-started` repo in VS Code, then make a copy of the `.env.example` file in the same directory and rename the copy as `.env`. You can also execute this command in your terminal:
+1. From the root directory of the `getting-started` repo, make a copy of the `.env` file you updated earlier and paste it into the /.devcontainer directory. You can also execute this command in your terminal:
    ```bash
-   cp .devcontainer/.env.example .devcontainer/.env
+   cp .env .devcontainer/.env
    ```
 
 2. Edit the `.env` and replace the `YOUR_SAND_API_KEY` string with your actual Sandgarden Director API key.
 
-3. Click the "Open a Remote Window" button in the bottom-left corner and select "Reopen in Container" from the menu.
+3. In VS Code, open the directory you cloned the `getting-started` repo to, then click the "Open a Remote Window" button in the bottom-left corner and select "Reopen in Container" from the menu.
    - This will start building the Dev Container, the first time you do it may take a few minutes to fully download build. Click “show log” in VSCode to check progress and as long as stuff is happening, it's all good.
 
 4. When the Dev Container finishes building, open another VS Code terminal and run `sand directors list` to confirm everything was successful - you should see an active Director listed. You should also see an active Director in the [Sandgarden Admin UI](https://app.sandgarden.com/infrastructure/directors).

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -34,9 +34,11 @@ Dev Container provides a complete development environment for Sandgarden workflo
 3. Click the "Open a Remote Window" button in the bottom-left corner and select "Reopen in Container" from the menu.
    - This will start building the Dev Container, the first time you do it may take a few minutes to fully download build. Click “show log” in VSCode to check progress and as long as stuff is happening, it's all good.
 
-4. When the Dev Container finishes building, open another VS Code terminal and run `sand directors list` to confirm the process completed successfully - you should see an active Director listed. You should also see an active Director in the [Sandgarden Admin UI](https://app.sandgarden.com/infrastructure/directors).
+4. When the Dev Container finishes building, open another VS Code terminal and run `sand directors list` to confirm everything was successful - you should see an active Director listed. You should also see an active Director in the [Sandgarden Admin UI](https://app.sandgarden.com/infrastructure/directors).
    ```bash
    sand directors list
    ```
 
-If a Director is active then your workspace will be mounted and ready for workflow development. Go to [the workflow directory](https://github.com/sandgardenhq/getting-started/workflow/README.md) in the `getting-started` repo and follow the ReadMe instructions there to try one of our pre-built workflows, or get started building your own project :)
+If a Director is active then your workspace will be mounted and ready for workflow development. 
+
+Go to [the workflow directory](https://github.com/sandgardenhq/getting-started/workflow/README.md) in the `getting-started` repo and follow the ReadMe instructions there to try one of our pre-built workflows, or get started building your own project :)

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+SSH_AUTH_SOCK_PATH=/run/host-services/ssh-auth.sock
+SAND_API_KEY=YOUR_SAND_API_KEY
+GIT_USER_NAME="Your Name"
+GIT_USER_EMAIL="Your Email"

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ setup.sh
 *.pywz
 *.pyzw
 staticcfg.json
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -16,14 +16,31 @@ To get started with Sandgarden you need a Director running to execute your code.
 - Coordinate complex batch processes
 - Ensure your code has access to required infrastructure
 
-### Running Directors
+_Technical Note: The director is a stateless Go binary designed to run in pools behind a load balancer for redundancy and scalability. Directors operate entirely in your environment while communicating with the control plane (app.sandgarden.com) for configuration, logs, and metrics._
+
+## Running Directors
 
 There are two ways to run directors:
 
-* For development:
+### For local development:
+
+#### Prerequisites for Local Development
+
+To get started in local developer mode, first prepare the following:
+
+1. Clone [this getting-started repo](https://github.com/sandgardenhq/getting-started.git), through either Git or VS Code.
+2. Create a Sandgarden API Key [through the Admin UI](https://app.sandgarden.com/settings/api-keys/new).
+   - Give a descriptive API Key Name (e.g. `deployment-key`).
+   - For Key Type, select "Director Key".
+   - For Expiration Date, choose a date conveniently far enough into the future (e.g. 30 days out).
+3. Make a copy of the `.env.example` file in the root directory where you cloned this project, renaming it `.env`
+   - `cp .env.example .env`
+   - Update `SAND_API_KEY=YOUR_SAND_API_KEY` and replace `YOUR_SAND_API_KEY` with the Sandgarden Director key you just created.
+3. _(Optional)_ Create an OpenAI API Key and keep it handy, if you would like to try one of our provided example workflows after deploying a Director.
+
   - [Run a director locally with Docker compose](/docker_compose/README.md)
   - [Run a dev container locally with VS Code or Cursor](/.devcontainer/README.md)
-* For production:
-  - [Deploy a pool of directors remotely in AWS](/aws/README.md)
 
-_Technical Note: The director is a stateless Go binary designed to run in pools behind a load balancer for redundancy and scalability. Directors operate entirely in your environment while communicating with the control plane (app.sandgarden.com) for configuration, logs, and metrics._
+
+### For production:
+  - [Deploy a pool of directors remotely in AWS](/aws/README.md)

--- a/docker_compose/.env.example
+++ b/docker_compose/.env.example
@@ -1,2 +1,0 @@
-SSH_AUTH_SOCK_PATH=/run/host-services/ssh-auth.sock
-SAND_API_KEY=YOUR_SAND_API_KEY

--- a/docker_compose/README.md
+++ b/docker_compose/README.md
@@ -39,4 +39,6 @@ This is very similar to the Dev Container mode and will start a Sandgarden Direc
    sand directors list
    ```
 
-If a Director is active, and the Sandgarden CLI is functioning, then your workspace is ready for workflow development. Go to [the workflow directory](https://github.com/sandgardenhq/getting-started/workflow/README.md) in the `getting-started` repo and follow the ReadMe instructions there to try one of our pre-built workflows, or get started building your own project :)
+If a Director is active, and the Sandgarden CLI is functioning, then your workspace is ready for workflow development. 
+
+Go to [the workflow directory](https://github.com/sandgardenhq/getting-started/workflow/README.md) in the `getting-started` repo and follow the ReadMe instructions there to try one of our pre-built workflows, or get started building your own project :)

--- a/docker_compose/README.md
+++ b/docker_compose/README.md
@@ -12,6 +12,9 @@ To get started in local developer mode, first prepare the following:
    - Give a descriptive API Key Name (e.g. `deployment-key`).
    - For Key Type, select "Director Key".
    - For Expiration Date, choose a date conveniently far enough into the future (e.g. 30 days out).
+3. Update the `.env` file in the directory where you cloned this project
+   - `cp .env.example .env`
+   - Update `SAND_API_KEY=YOUR_SAND_API_KEY` and replace `YOUR_SAND_API_KEY` with the director key you just created
 3. _(Optional)_ Create an OpenAI API Key and keep it handy, if you would like to try one of our provided example workflows after deploying a Director.
 
 
@@ -21,24 +24,17 @@ This is very similar to the Dev Container mode and will start a Sandgarden Direc
 
 ### Setup
 
-1. Make a copy of the `docker_compose/.env.example` file, keeping it in the same directory, and rename the copy as `.env`. You can also execute this command in your terminal:
-   ```bash
-   cp docker_compose/.env.example docker_compose/.env
-   ```
-
-2. Edit the `.env` and replace the `YOUR_SAND_API_KEY` string with your actual Sandgarden Director API key.
-
-3. From the root directory of the `getting-started` repo, start the docker container:
+1. From the root directory of the `getting-started` repo, start the docker container:
    ```bash
    docker compose -f docker_compose/docker-compose.yml up --detach
    ```
 
-4. From the root directory of the `getting-started` repo, run the script to install the Sandgarden CLI:
+2. From the root directory of the `getting-started` repo, run the script to install the Sandgarden CLI:
    ```bash
    ./install_cli.sh
    ```
 
-5. Run `sand directors list` to confirm everything was successful - you should see an active Director listed. You should also see an active Director in the [Sandgarden Admin UI](https://app.sandgarden.com/infrastructure/directors).
+3. Run `sand directors list` to confirm everything was successful - you should see an active Director listed. You should also see an active Director in the [Sandgarden Admin UI](https://app.sandgarden.com/infrastructure/directors).
    ```bash
    sand directors list
    ```

--- a/docker_compose/README.md
+++ b/docker_compose/README.md
@@ -12,9 +12,9 @@ To get started in local developer mode, first prepare the following:
    - Give a descriptive API Key Name (e.g. `deployment-key`).
    - For Key Type, select "Director Key".
    - For Expiration Date, choose a date conveniently far enough into the future (e.g. 30 days out).
-3. Update the `.env` file in the root directory where you cloned this project
+3. Make a copy of the `.env.example` file in the root directory where you cloned this project, renaming it `.env`
    - `cp .env.example .env`
-   - Update `SAND_API_KEY=YOUR_SAND_API_KEY` and replace `YOUR_SAND_API_KEY` with the director key you just created
+   - Update `SAND_API_KEY=YOUR_SAND_API_KEY` and replace `YOUR_SAND_API_KEY` with the Sandgarden Director key you just created.
 3. _(Optional)_ Create an OpenAI API Key and keep it handy, if you would like to try one of our provided example workflows after deploying a Director.
 
 

--- a/docker_compose/README.md
+++ b/docker_compose/README.md
@@ -3,21 +3,6 @@
 Local developer mode runs a Sandgarden director in a local docker image on your development machine.
 It's a simple way to get started with Sandgarden without having to set up a cloud environment, and it lets you test your changes as you make them.
 
-## Prerequisites
-
-To get started in local developer mode, first prepare the following:
-
-1. Clone [this getting-started repo](https://github.com/sandgardenhq/getting-started.git), through either Git or VS Code.
-2. Create a Sandgarden API Key [through the Admin UI](https://app.sandgarden.com/settings/api-keys/new).
-   - Give a descriptive API Key Name (e.g. `deployment-key`).
-   - For Key Type, select "Director Key".
-   - For Expiration Date, choose a date conveniently far enough into the future (e.g. 30 days out).
-3. Make a copy of the `.env.example` file in the root directory where you cloned this project, renaming it `.env`
-   - `cp .env.example .env`
-   - Update `SAND_API_KEY=YOUR_SAND_API_KEY` and replace `YOUR_SAND_API_KEY` with the Sandgarden Director key you just created.
-3. _(Optional)_ Create an OpenAI API Key and keep it handy, if you would like to try one of our provided example workflows after deploying a Director.
-
-
 ## Docker Compose
 
 This is very similar to the Dev Container mode and will start a Sandgarden Director in a local docker container with a complete development environment for Sandgarden workflows.

--- a/docker_compose/README.md
+++ b/docker_compose/README.md
@@ -26,12 +26,12 @@ This is very similar to the Dev Container mode and will start a Sandgarden Direc
 
 1. From the root directory of the `getting-started` repo, start the docker container:
    ```bash
-   docker compose -f docker_compose/docker-compose.yml up --detach
+   docker compose -f docker_compose/docker-compose.yml --env-file .env up --detach
    ```
 
 2. From the root directory of the `getting-started` repo, run the script to install the Sandgarden CLI:
    ```bash
-   ./install_cli.sh
+   source ./install_cli.sh
    ```
 
 3. Run `sand directors list` to confirm everything was successful - you should see an active Director listed. You should also see an active Director in the [Sandgarden Admin UI](https://app.sandgarden.com/infrastructure/directors).

--- a/docker_compose/README.md
+++ b/docker_compose/README.md
@@ -12,7 +12,7 @@ To get started in local developer mode, first prepare the following:
    - Give a descriptive API Key Name (e.g. `deployment-key`).
    - For Key Type, select "Director Key".
    - For Expiration Date, choose a date conveniently far enough into the future (e.g. 30 days out).
-3. Update the `.env` file in the directory where you cloned this project
+3. Update the `.env` file in the root directory where you cloned this project
    - `cp .env.example .env`
    - Update `SAND_API_KEY=YOUR_SAND_API_KEY` and replace `YOUR_SAND_API_KEY` with the director key you just created
 3. _(Optional)_ Create an OpenAI API Key and keep it handy, if you would like to try one of our provided example workflows after deploying a Director.

--- a/install_cli.sh
+++ b/install_cli.sh
@@ -89,7 +89,7 @@ mv sand "$INSTALL_DIR"
 cd - > /dev/null
 rm -rf "$TMP_DIR"
 
-# Export the API Key from docker_compose/.env file and set it as an env var for CLI usage
-set -o allexport; source docker_compose/.env; set +o allexport
+# Export the API Key from .env file and set it as an env var for CLI usage
+set -o allexport; source .env; set +o allexport
 
 echo "Sandgarden CLI installed successfully!"

--- a/install_cli.sh
+++ b/install_cli.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# Function to safely exit or return
+safe_exit() {
+    if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+        # If sourced, use return
+        return 1
+    else
+        # If executed directly, use exit
+        exit 1
+    fi
+}
+
 # Detect OS and architecture
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
@@ -14,7 +25,7 @@ case $ARCH in
         ;;
     *)
         echo "Unsupported architecture: $ARCH"
-        exit 1
+        safe_exit
         ;;
 esac
 
@@ -23,9 +34,12 @@ case $OS in
     "darwin")
         OS="osx"
         ;;
+    "linux")
+        OS="linux"
+        ;;
     *)
-        echo "Unsupported architecture: $OS"
-        exit 1
+        echo "Unsupported OS: $OS"
+        safe_exit
         ;;
 esac
 
@@ -44,52 +58,102 @@ curl -L "$URL" -o sand
 chmod 0755 sand
 
 # Find a suitable location in PATH
-DEFAULT_DIR=""
+DEFAULT_DIR="$HOME/bin"
 
-# Check preferred locations first
-for dir in "/usr/local/bin" "$HOME/bin"; do
-    if [ -w "$dir" ]; then
-        DEFAULT_DIR="$dir"
-        break
+# Check if ~/bin exists, if not, create it
+if [ ! -d "$DEFAULT_DIR" ]; then
+    echo "Creating directory $DEFAULT_DIR"
+    mkdir -p "$DEFAULT_DIR"
+    # Add to PATH if not already there
+    if [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
+        echo "Adding $DEFAULT_DIR to PATH in your shell profile"
+        # Determine shell and update appropriate profile
+        if [ -n "$BASH_VERSION" ]; then
+            echo 'export PATH="$HOME/bin:$PATH"' >> "$HOME/.bashrc"
+        elif [ -n "$ZSH_VERSION" ]; then
+            echo 'export PATH="$HOME/bin:$PATH"' >> "$HOME/.zshrc"
+        else
+            echo "Please add $DEFAULT_DIR to your PATH manually"
+        fi
     fi
-done
+fi
 
-# Fall back to first writable directory in PATH if no preferred location is available
+# Double check the directory is writable
+if [ ! -w "$DEFAULT_DIR" ]; then
+    echo "WARNING: $DEFAULT_DIR is not writable. Trying /usr/local/bin instead."
+    DEFAULT_DIR="/usr/local/bin"
+    if [ ! -w "$DEFAULT_DIR" ]; then
+        echo "ERROR: Neither $HOME/bin nor /usr/local/bin are writable."
+        echo "Please specify a writable directory manually."
+        DEFAULT_DIR=""
+    fi
+fi
+
+# If we still don't have a default dir, check PATH directories
 if [ -z "$DEFAULT_DIR" ]; then
-    for dir in ${PATH//:/ }; do
-        if [ -w "$dir" ]; then
+    IFS=':' read -ra DIRS <<< "$PATH"
+    for dir in "${DIRS[@]}"; do
+        if [ -d "$dir" ] && [ -w "$dir" ]; then
             DEFAULT_DIR="$dir"
             break
         fi
     done
 fi
 
+# If still no writable directory found
 if [ -z "$DEFAULT_DIR" ]; then
-    echo "No writable directory found in PATH"
-    exit 1
+    echo "No writable directory found in PATH."
+    echo "Will install to current directory."
+    DEFAULT_DIR="$(pwd)"
 fi
 
-# Prompt for installation directory
-read -p "Enter installation directory [$DEFAULT_DIR]: " INSTALL_DIR
+# Prompt for installation directory - handling different shells
+echo "Enter installation directory [$DEFAULT_DIR]: "
+read INSTALL_DIR
 INSTALL_DIR=${INSTALL_DIR:-$DEFAULT_DIR}
-INSTALL_DIR=$(echo "$INSTALL_DIR" | sed "s|~|$HOME|")
-INSTALL_DIR=$(realpath "$INSTALL_DIR")
+
+# Handle ~ expansion
+INSTALL_DIR="${INSTALL_DIR/#\~/$HOME}"
+
+# Create directory if it doesn't exist
+if [ ! -d "$INSTALL_DIR" ]; then
+    echo "Directory $INSTALL_DIR does not exist. Creating it..."
+    mkdir -p "$INSTALL_DIR" || {
+        echo "Failed to create directory $INSTALL_DIR"
+        safe_exit
+    }
+fi
 
 # Verify directory is writable
 if [ ! -w "$INSTALL_DIR" ]; then
     echo "Error: Directory $INSTALL_DIR is not writable"
-    exit 1
+    safe_exit
 fi
 
 # Move binary to installation directory
 echo "Installing to $INSTALL_DIR..."
-mv sand "$INSTALL_DIR"
+mv sand "$INSTALL_DIR/"
 
 # Cleanup
-cd - > /dev/null
+cd "$OLDPWD" || cd "$HOME"
 rm -rf "$TMP_DIR"
 
 # Export the API Key from .env file and set it as an env var for CLI usage
-set -o allexport; source .env; set +o allexport
+if [ -f ".env" ]; then
+    set -o allexport
+    source .env
+    set +o allexport
+    echo "Loaded environment variables from .env file"
+else
+    echo "Warning: .env file not found. SAND_API_KEY not set."
+fi
 
-echo "Sandgarden CLI installed successfully!"
+echo "Sandgarden CLI installed successfully to $INSTALL_DIR/sand"
+echo "Make sure $INSTALL_DIR is in your PATH"
+
+# Verify the API key is set
+if [ -n "$SAND_API_KEY" ]; then
+    echo "SAND_API_KEY is set"
+else
+    echo "SAND_API_KEY is not set. Please set it manually or create a .env file"
+fi

--- a/install_workflow.sh
+++ b/install_workflow.sh
@@ -1,21 +1,31 @@
 #!/bin/bash
 
 # Parse command line arguments
-FORCE=false
-while [[ "$#" -gt 0 ]]; do
-    case $1 in
-        --force) FORCE=true ;;
-        *) echo "Unknown parameter: $1"; exit 1 ;;
-    esac
-    shift
-done
+#FORCE=false
+#while [[ "$#" -gt 0 ]]; do
+#    case $1 in
+#        --force) FORCE=true ;;
+#        *) echo "Unknown parameter: $1"; exit 1 ;;
+#    esac
+#    shift
+#done
 
 # Check if we're in the root of the getting-started repo
-if [[ "$FORCE" == false && ($(basename "$PWD") != "getting-started" || $(basename "$PWD") != "sandgarden") ]]; then
-    echo "Error: This script must be run from the root of the getting-started repo"
-    echo "If you cloned the repo into a different directory, use --force to bypass this check"
-    exit 1
-fi
+#if [[ "$FORCE" == false && ($(basename "$PWD") != "getting-started" || $(basename "$PWD") != "sandgarden") ]]; then
+#    echo "Error: This script must be run from the root of the getting-started repo"
+#    echo "If you cloned the repo into a different directory, use --force to bypass this check"
+#    exit 1
+#fi
+
+safe_exit() {
+    if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+        # If sourced, use return
+        return 1
+    else
+        # If executed directly, use exit
+        exit 1
+    fi
+}
 
 # Check if sand CLI is installed
 if ! command -v sand &> /dev/null; then
@@ -24,7 +34,7 @@ if ! command -v sand &> /dev/null; then
         bash install_cli.sh
     else
         echo "Error: install_cli.sh not found"
-        exit 1
+        safe_exit
     fi
 fi
 
@@ -36,7 +46,8 @@ set -o allexport; source .env; set +o allexport
 if [ -z "$SAND_API_KEY" ]; then
     echo "Please visit https://app.sandgarden.com/settings/api-keys to create an API key."
     echo "Click 'Create API Key' and make sure to select director access."
-    read -p "Enter your API key: " SAND_API_KEY
+    echo "Enter your API key: "
+    read SAND_API_KEY
 fi
 
 # Create a cluster
@@ -48,7 +59,8 @@ fi
 
 # Prompt for OpenAI API Key
 if [ -z "$OPENAI_API_KEY" ]; then
-    read -p "Enter your OpenAI API key: " OPENAI_API_KEY
+    echo "Enter your OpenAI API key: "
+    read OPENAI_API_KEY
 fi
 
 # Create an OpenAI connector

--- a/install_workflow.sh
+++ b/install_workflow.sh
@@ -28,6 +28,10 @@ if ! command -v sand &> /dev/null; then
     fi
 fi
 
+# Export the API Key from .env file and set it as an env var for CLI usage
+set -o allexport; source .env; set +o allexport
+
+
 # Get Sandgarden API Key
 if [ -z "$SAND_API_KEY" ]; then
     echo "Please visit https://app.sandgarden.com/settings/api-keys to create an API key."

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -11,7 +11,7 @@ This is an example workflow that loads the CF-TriviaQA dataset and answers some 
 
 ### 1. Run install_workflow.sh
 ```bash
-./install_workflow.sh
+source ./install_workflow.sh
 ```
 
 ### 2. Run it!


### PR DESCRIPTION
Moved .env.example to root project directory, updated READMEs to reflect the change, and update the primary README to walk them through updating the .env with API key as a prerequisite before anything else.